### PR TITLE
another update to ID3A-FOXDEN.json

### DIFF
--- a/schemas/ID3A-FOXDEN.json
+++ b/schemas/ID3A-FOXDEN.json
@@ -526,7 +526,7 @@
     ]
   },
   {
-    "key": "processing",
+    "key": "processing_environment",
     "type": "list_str",
     "optional": true,
     "multiple": false,


### PR DESCRIPTION
Missed this one in my previous update - changed key "processing" to "processing_environment" to avoid clash with a reserved key name.